### PR TITLE
2.7.2

### DIFF
--- a/DebugTest.lua
+++ b/DebugTest.lua
@@ -59,7 +59,7 @@ end
 
 -- Test for https://www.curseforge.com/wow/addons/toy-box-enhanced/issues/16
 local function UnusableTest()
-    if UnitLevel("player") < 50 and C_ToyBox.IsToyUsable(95589) or C_ToyBox.IsToyUsable(85500) then
+    if (UnitLevel("player") < 50 and C_ToyBox.IsToyUsable(95589)) or C_ToyBox.IsToyUsable(85500) then
         print("TBE: C_ToyBox.IsToyUsable() has been fixed!?")
     end
 end

--- a/Favorites.lua
+++ b/Favorites.lua
@@ -19,7 +19,7 @@ function ADDON:CollectFavoredToys()
 end
 
 local function FavorToys(itemIds, finishedCallback)
-    -- appearantly Blizzard only allows ~5 requests per second
+    -- apparently WoW only allows ~5 requests per second
 
     if starButton then
         starButton:Disable()

--- a/Favorites.lua
+++ b/Favorites.lua
@@ -45,17 +45,16 @@ local function FavorToys(itemIds, finishedCallback)
         end
     end
 
-    if ADDON.initialized then
-        ADDON:FilterAndRefresh()
-    end
-
     if updateCount > 0 then
         C_Timer.After(1, function()
             FavorToys(itemIds, finishedCallback)
         end)
-    elseif finishedCallback then
+    else
         if starButton then
             starButton:Enable()
+        end
+        if ADDON.initialized then
+            ADDON:FilterAndRefresh()
         end
         finishedCallback()
     end

--- a/Filters.lua
+++ b/Filters.lua
@@ -2,6 +2,10 @@ local ADDON_NAME, ADDON = ...
 
 local function FilterBySearch(itemId, searchString)
     local _, name = C_ToyBox.GetToyInfo(itemId)
+    if name == nil or name == '' then
+        return false
+    end
+
     name = name:lower()
     local pos = strfind(name, searchString, 1, true)
     local result = pos ~= nil
@@ -9,11 +13,13 @@ local function FilterBySearch(itemId, searchString)
         return result
     end
 
-    local _, spellId = GetItemSpell(itemId)
-    local spellDescription = GetSpellDescription(spellId)
-    spellDescription = spellDescription:lower()
-    pos = strfind(spellDescription, searchString, 1, true)
-    result = pos ~= nil
+    if ADDON.settings.searchInDescription then
+        local _, spellId = GetItemSpell(itemId)
+        local spellDescription = GetSpellDescription(spellId)
+        spellDescription = spellDescription:lower()
+        pos = strfind(spellDescription, searchString, 1, true)
+        result = pos ~= nil
+    end
 
     return result
 end
@@ -31,7 +37,7 @@ local function FilterCollectedToys(itemId)
 end
 
 local function FilterFavoriteToys(itemId)
-    return not ADDON.settings.filter.onlyFavorites or not ADDON.settings.filter.collected or select(4, C_ToyBox.GetToyInfo(itemId))
+    return not ADDON.settings.filter.onlyFavorites or not ADDON.settings.filter.collected or C_ToyBox.GetIsFavorite(itemId)
 end
 
 local function FilterUsableToys(itemId)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Toy Box Enhanced extends the default Toy Box.
 ### Known Limitations
 For technical reasons it's not possible to use some enhanced features during combat.
 
-### Help
+### Help wanted
 
-Have you found any bug or do you have some suggestions? Please let me know in the issue tracker on [Curseforge](https://www.curseforge.com/wow/addons/toy-box-enhanced/issues) or [Github](https://github.com/exochron/ToyBoxEnhanced/issues).
-
-You can also help me to [localize the addon into your language](https://www.curseforge.com/wow/addons/toy-box-enhanced/localization).
+- Have you found any bug or do you have some suggestions? Please let me know in the issue tracker on [Curseforge](https://www.curseforge.com/wow/addons/toy-box-enhanced/issues) or [GitHub](https://github.com/exochron/ToyBoxEnhanced/issues).
+- Is your language still missing some texts? You can localize the addon into your language on [Curseforge](https://www.curseforge.com/wow/addons/toy-box-enhanced/localization).
+- Want to try out some cool new stuff earlier than everybody else? Just switch to the Beta-Channel in your Addon Updater and let me know of anything you might find in our issue tracker. After a few days without bugs the same version goes stable for everybody else.
+- Are you interested in developing as well? Come join us at [GutHub](https://github.com/exochron/ToyBoxEnhanced). And don't worry about knowing nothing of LUA. It's easy to learn. ;-)

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ For technical reasons it's not possible to use some enhanced features during com
 - Have you found any bug or do you have some suggestions? Please let me know in the issue tracker on [Curseforge](https://www.curseforge.com/wow/addons/toy-box-enhanced/issues) or [GitHub](https://github.com/exochron/ToyBoxEnhanced/issues).
 - Is your language still missing some texts? You can localize the addon into your language on [Curseforge](https://www.curseforge.com/wow/addons/toy-box-enhanced/localization).
 - Want to try out some cool new stuff earlier than everybody else? Just switch to the Beta-Channel in your Addon Updater and let me know of anything you might find in our issue tracker. After a few days without bugs the same version goes stable for everybody else.
-- Are you interested in developing as well? Come join us at [GutHub](https://github.com/exochron/ToyBoxEnhanced). And don't worry about knowing nothing of LUA. It's easy to learn. ;-)
+- Are you interested in developing addons as well? Then come join us at [GutHub](https://github.com/exochron/ToyBoxEnhanced). And don't worry about knowing nothing of LUA. It's easy to learn. ;-)

--- a/ToyBoxEnhanced.lua
+++ b/ToyBoxEnhanced.lua
@@ -125,11 +125,11 @@ frame:SetScript("OnEvent", function(self, event, arg1)
     elseif event == "PLAYER_LOGIN" and false == playerLoggedIn then
         ResetAPIFilters()
 
-        if C_ToyBox.GetNumFilteredToys() < 555 then
+        if C_ToyBox.GetNumFilteredToys() <= 600 then
             delayLoginUntilFullyLoaded = true
         end
         playerLoggedIn = true
-    elseif event == "TOYS_UPDATED" and delayLoginUntilFullyLoaded and playerLoggedIn and nil == arg1 and C_ToyBox.GetNumFilteredToys() > 555 then
+    elseif event == "TOYS_UPDATED" and delayLoginUntilFullyLoaded and playerLoggedIn and nil == arg1 and C_ToyBox.GetNumFilteredToys() > 600 then
         delayLoginUntilFullyLoaded = false
     end
 

--- a/UI/EnhancedLayer.lua
+++ b/UI/EnhancedLayer.lua
@@ -196,14 +196,13 @@ ADDON:RegisterLoadUICallback(function()
     for i = 1, ADDON.TOYS_PER_PAGE do
         local button = layer["spellButton" .. i]
         button:HookScript("OnClick", function(self, button)
-            if (IsModifiedClick()) then
+            if IsModifiedClick() then
                 ToySpellButton_OnModifiedClick(self, button)
             end
         end)
     end
 
     layer:SetShown(not InCombatLockdown())
-    ToyBox.EnhancedLayer = layer
 
     hooksecurefunc("ToyBox_UpdatePages", function()
         local maxPages = 1 + math.floor( math.max((#ADDON.filteredToyList - 1), 0) / ADDON.TOYS_PER_PAGE)

--- a/UI/Templates.xml
+++ b/UI/Templates.xml
@@ -160,7 +160,7 @@
     </CheckButton>
 
     <!-- from Toybox.iconsFrame -->
-    <Frame name="TBEButtonFrameTemplate" inherits="CollectionsBackgroundTemplate" virtual="true" enablemouse="true">
+    <Frame name="TBEButtonFrameTemplate" parentKey="EnhancedLayer" inherits="CollectionsBackgroundTemplate" virtual="true" enablemouse="true">
         <Layers>
             <Layer level="BACKGROUND" textureSubLevel="-6">
                 <Texture file="Interface\FrameGeneral\UI-Background-Rock" horizTile="true" vertTile="true">
@@ -180,6 +180,12 @@
         </Layers>
         <!-- Toy Buttons -->
         <Frames>
+            <Frame parentKey="PagingFrame" inherits="CollectionsPagingFrameTemplate">
+                <Anchors>
+                    <Anchor point="BOTTOM" x="22" y="38"/>
+                </Anchors>
+            </Frame>
+
             <CheckButton parentKey="spellButton1" inherits="TBEToySpellButtonTemplate" id="1">
                 <Anchors>
                     <Anchor point="TOPLEFT" x="40" y="-53" />
@@ -270,12 +276,6 @@
                     <Anchor point="TOPLEFT" relativeKey="$parent.spellButton17" x="208" y="0" />
                 </Anchors>
             </CheckButton>
-
-            <Frame parentKey="PagingFrame" inherits="CollectionsPagingFrameTemplate">
-                <Anchors>
-                    <Anchor point="BOTTOM" x="22" y="38"/>
-                </Anchors>
-            </Frame>
         </Frames>
     </Frame>
 


### PR DESCRIPTION
 - preload uncached toy data in game client (#26, #27)
- refresh filters only at end of mass favorites (#26, #27)
- catch empty toy name on filter and sort (#26, #27)
- filter: actually use the option to search in description
- UI: fixed Layer initialisation coming out of combat with Toybox open
- db: automatically cleanup toys.db.lua on removed items